### PR TITLE
Fix deprecated include to asm/uaccess.h

### DIFF
--- a/afulnx64/driver/amiwrap.c
+++ b/afulnx64/driver/amiwrap.c
@@ -13,6 +13,7 @@
 #include <linux/vmalloc.h>
 #include <linux/mman.h>
 #include <linux/slab.h>
+#include <linux/uaccess.h>
 #include <asm/io.h>
 #include <asm/uaccess.h>
 


### PR DESCRIPTION
Newer kernel versions use linux/uaccess.h instead.